### PR TITLE
Removes the whitespace in <tag >

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl extension SVG.
 
 2.65 Unknown
     - Correct some spelling errors that were detected by codespell.
+    - Don't insert whitespace between tag name and closing bracked when a tag has no attributes
 
 2.64 2015.06.02
     - RT #103938 SVG::DOM insertSiblingAfter calls nonexistent 'parent' method (Marius Gavrilescu)

--- a/lib/SVG/XML.pm
+++ b/lib/SVG/XML.pm
@@ -85,14 +85,14 @@ sub cssstyle {
 # Per suggestion from Adam Schneider
 sub xmlattrib {
     my %attrs = @_;
-    return (
-        join( ' ', map { qq($_=") . $attrs{$_} . q(") } sort keys(%attrs) ) );
+    return '' if !%attrs;
+    return (' ' . join( ' ', map { qq($_=") . $attrs{$_} . q(") } sort keys(%attrs) ) );
 }
 
 sub xmltag {
     my ( $name, $ns, %attrs ) = @_;
     $ns = $ns ? "$ns:" : '';
-    my $at = ' ' . xmlattrib(%attrs) || '';
+    my $at = xmlattrib(%attrs) || '';
     return qq(<$ns$name$at />);
 }
 
@@ -104,7 +104,7 @@ sub xmltag_ln {
 sub xmltagopen {
     my ( $name, $ns, %attrs ) = @_;
     $ns = $ns ? "$ns:" : '';
-    my $at = ' ' . xmlattrib(%attrs) || '';
+    my $at = xmlattrib(%attrs) || '';
     return qq(<$ns$name$at>);
 }
 

--- a/t/03-render.t
+++ b/t/03-render.t
@@ -15,4 +15,4 @@ like $output,
     qr{<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">};
 like $output,
     qr{<svg height="100%" width="100%" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">};
-like $output, qr{<circle  />};
+like $output, qr{<circle />};

--- a/t/04-inline.t
+++ b/t/04-inline.t
@@ -15,7 +15,7 @@ unlike $xml1a, qr/DOCTYPE/, "1 render inline document";
 unlike $xml1a, qr/^<\?xml .*?\?>\s*/sm;
 like $xml1a,
     qr{<svg height="100%" width="100%" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">};
-like $xml1a, qr{<text >An inline document</text>};
+like $xml1a, qr{<text>An inline document</text>};
 
 my $xml1b = $svg1->render( -inline => 0 );
 like $xml1b, qr/DOCTYPE/, "2 render not inline";


### PR DESCRIPTION
Hi,

This change checks if there are any attributes before putting in a space before the closing bracket. Also adjusted a couple of tests that depended on the space.
