### PR TITLE
Fix entity escaping

### DIFF
--- a/lib/SVG/XML.pm
+++ b/lib/SVG/XML.pm
@@ -76,7 +76,7 @@ sub xmlescp {
     }
 
     # Per suggestion from Adam Schneider
-    $s =~ s/([\200-\377])/' &    #'.ord($1).';'/ge;
+    $s =~ s/([\200-\377])/'&#'.ord($1).';'/ge;
 
     return $s;
 }


### PR DESCRIPTION
Extra white space was added in a misguided attempt to comply with Perl::Critic policies.