### PR TITLE
Documentation fixes

### DIFF
--- a/lib/SVG.pm
+++ b/lib/SVG.pm
@@ -86,8 +86,9 @@ See the other modules in this distribution:
 L<SVG::DOM>,
 L<SVG::XML>,
 L<SVG::Element>,
-L<SVG::Parser>,
-L<SVG::Extension>
+and L<SVG::Extension>.
+
+See L<SVG::Parser> for reading SVG files as C<SVG> objects.
 
 =head2 Converting SVG to PNG and other raster image formats
 
@@ -1588,8 +1589,6 @@ L<SVG::Parser>,
 L<SVG::Extension>
 
 For Commercial Perl/SVG development, refer to the following sites:
-L<ROASP.com: Serverside SVG server|http://www.roitsystems.com/>,
-L<ROIT Systems: Commercial SVG perl solutions|http://www.roitsystems.com/>,
-L<SVG at the W3C|http://www.w3c.org/Graphics/SVG/>
+L<SVG at the W3C|http://www.w3c.org/Graphics/SVG/>.
 
 =cut

--- a/lib/SVG/DOM.pm
+++ b/lib/SVG/DOM.pm
@@ -619,7 +619,7 @@ and so on.
 
 =head1 SYNOPSIS
 
-    my $svg=new SVG(id=>"svg_dom_synopsis", width=>"100", height=>"100");
+    my $svg=SVG->new(id=>"svg_dom_synopsis", width=>"100", height=>"100");
     my %attributes=$svg->getAttributes;
 
     my $group=$svg->group(id=>"group_1");
@@ -798,7 +798,6 @@ Martin Owens, doctormo@postmaster.co.uk
 
 perl(1), L<SVG>, L<SVG::XML>, L<SVG::Element>, L<SVG::Parser>
 
-L<http://www.roitsystems.com/> ROIT Systems: Commercial SVG perl solutions
 L<http://www.w3c.org/Graphics/SVG/> SVG at the W3C
 
 =cut


### PR DESCRIPTION
This PR is about fixing a couple of minor documentation issues:

- SVG::Parser is no more included in this distribution, so it's better not to make it look as it is;
- The example in SVG::DOM was using the indirect object notation, which is something we should steer away from;
- Many links pointed to places that are no more available, unfortunately.