### PR TITLE
Replace last use of "vars" with "our"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,6 @@ WriteMakefile(
         'warnings'     => 0,
         'constant'     => 0,
         'parent'       => 0,
-        'vars'         => 0,
         'Exporter'     => 0,
         'Scalar::Util' => 0,
     },

--- a/lib/SVG/XML.pm
+++ b/lib/SVG/XML.pm
@@ -30,10 +30,10 @@ L<SVG at the W3C|http://www.w3c.org/Graphics/SVG/>
 =cut
 
 use Exporter;
-use vars qw(@ISA @EXPORT);
-@ISA = ('Exporter');
 
-@EXPORT = qw(
+our @ISA = ('Exporter');
+
+our @EXPORT = qw(
     xmlesc
     xmlescape
     xmlescp


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist depends on 5.06+ and already uses "our" elsewhere.