### PR TITLE
Allow non perl numbers, such as PDL scalars

### DIFF
--- a/lib/SVG/Element.pm
+++ b/lib/SVG/Element.pm
@@ -104,7 +104,7 @@ sub xmlify {
         elsif ( ref( $self->{$k} ) eq 'HASH' ) {
             $attrs{$k} = cssstyle( %{ $self->{$k} } );
         }
-        elsif ( ref( $self->{$k} ) eq '' ) {
+        else {
             $attrs{$k} = $self->{$k};
         }
     }


### PR DESCRIPTION
Remove a test in Element.pm
This allows using PDL scalars in attributes, such as in
```
use SVG; use PDL; use PDL::NiceSlice;
my $points=pdl(sequence(10), sequence(10)**2)->transpose;
my $svg=SVG->new;
$svg->circle(cx=>$_((0)), cy=>$_((1)), r=>3) for($points->dog);
say $svg->xmlify;
```
which puts ten circles along a parabola.